### PR TITLE
Include the payload with 'authenticated' event

### DIFF
--- a/lib/socketio-auth.js
+++ b/lib/socketio-auth.js
@@ -49,7 +49,7 @@ module.exports = function(io, config){
           _.each(io.nsps, function(nsp) {
             restoreConnection(nsp, socket);
           });
-          socket.emit('authenticated');
+          socket.emit('authenticated', success);
           return postAuthenticate(socket, data);
         }
         socket.disconnect('unauthorized', {err: err});
@@ -67,3 +67,4 @@ module.exports = function(io, config){
 
   });
 }
+


### PR DESCRIPTION
Would be nice if the authenticated object can be passed along with the `authenticated` event.