### PR TITLE
Use same variable name in server as in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The client just needs to make sure to authenticate after connecting:
 ```javascript
 var socket = io.connect('http://localhost');
 socket.on('connect', function(){
-  socket.emit('authentication', {client: "John", password: "secret"});
+  socket.emit('authentication', {username: "John", password: "secret"});
 });
 ```
 The server will emit the `authenticated` event to confirm authentication.


### PR DESCRIPTION
It took me a while to understand why this wasn't working, turns out the names for the user differ. Correct if I'm worng. Please check if this needs to be changed as well: socket.client.user = user;